### PR TITLE
Update MinecraftHandler to include additional skin domains

### DIFF
--- a/src/Gml.Web.Api/Core/Handlers/IMinecraftHandler.cs
+++ b/src/Gml.Web.Api/Core/Handlers/IMinecraftHandler.cs
@@ -1,10 +1,11 @@
 using Gml.Web.Api.Core.Options;
 using Gml.Web.Api.Core.Services;
+using GmlCore.Interfaces;
 using Microsoft.Extensions.Options;
 
 namespace Gml.Web.Api.Core.Handlers;
 
 public interface IMinecraftHandler
 {
-    static abstract Task<IResult> GetMetaData(ISystemService systemService, IOptions<ServerSettings> options);
+    static abstract Task<IResult> GetMetaData(ISystemService systemService, IGmlManager gmlManager, IOptions<ServerSettings> options);
 }


### PR DESCRIPTION
The method `GetMetaData` within `MinecraftHandler` and `IMinecraftHandler` was updated to accept `IGmlManager` as a new parameter. This change will allow the retrieval of additional skin domains from the environment. The logic was added to obtain skin and cloak service addresses and to append them to the existing skinDomain list, ensuring that there are no duplicates.