### PR TITLE
Implement access token validation for API endpoints

### DIFF
--- a/src/Gml.Web.Api.EndpointSDK/PathAttribute.cs
+++ b/src/Gml.Web.Api.EndpointSDK/PathAttribute.cs
@@ -2,8 +2,9 @@ using System;
 
 namespace Gml.Web.Api.EndpointSDK;
 
-public class PathAttribute(string? method, string? path) : Attribute
+public class PathAttribute(string? method, string? path, bool needAuth) : Attribute
 {
     public string? Method { get; set; } = method;
     public string? Path { get; set; } = path;
+    public bool NeedAuth { get; set; } = needAuth;
 }

--- a/src/Gml.Web.Api.Plugins.Template/TemplateEndpoint.cs
+++ b/src/Gml.Web.Api.Plugins.Template/TemplateEndpoint.cs
@@ -4,11 +4,11 @@ using Microsoft.AspNetCore.Http;
 
 namespace Gml.Web.Api.Plugins.Template;
 
-[Path("get", "/api/v1/plugins/template")]
+[Path("get", "/api/v1/plugins/template", true)]
 public class TemplateEndpoint : IPluginEndpoint
 {
     public async Task Execute(HttpContext context)
     {
-        await context.Response.WriteAsync("template123123");
+        await context.Response.WriteAsync("template");
     }
 }

--- a/src/Gml.Web.Api/Core/Extensions/ApplicationExtensions.cs
+++ b/src/Gml.Web.Api/Core/Extensions/ApplicationExtensions.cs
@@ -124,7 +124,6 @@ public static class ApplicationExtensions
 
         builder.Services
             .AddHttpClient()
-
             .AddDbContext<DatabaseContext>(options =>
                 options.UseSqlite(builder.Configuration.GetConnectionString("SQLite")))
             .AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies().AsEnumerable())
@@ -135,6 +134,7 @@ public static class ApplicationExtensions
             .AddSingleton<IAuthService, AuthService>()
             .AddSingleton<IGitHubService, GitHubService>()
             .AddSingleton<ApplicationContext>()
+            .AddSingleton<AccessTokenService>()
             .AddTransient<UndefinedAuthService>()
             .AddTransient<DataLifeEngineAuthService>()
             .AddTransient<AzuriomAuthService>()


### PR DESCRIPTION
An AccessTokenService has been added as a singleton to the ApplicationExtensions. This service validates tokens for authorized endpoints, with the token validation process detailed within the AccessTokenService itself. The PathAttribute has been updated to require a 'needAuth' parameter to determine if authorization is required for an endpoint. Modifications have also been made to the PluginMiddleware to validate tokens when necessary. If a token is invalid or missing when required