### PR TITLE
Fix file reference in ProfileHandler

### DIFF
--- a/src/Gml.Web.Api/Core/Handlers/ProfileHandler.cs
+++ b/src/Gml.Web.Api/Core/Handlers/ProfileHandler.cs
@@ -121,7 +121,7 @@ public class ProfileHandler : IProfileHandler
             ? null
             : context.Request.Form.Files["icon"]!.OpenReadStream();
 
-        var background = context.Request.Form.Files["icon"] is null
+        var background = context.Request.Form.Files["background"] is null
             ? null
             : context.Request.Form.Files["background"]!.OpenReadStream();
 


### PR DESCRIPTION
The file reference for the background image was incorrectly pointing to the icon. This commit corrects the reference to point to the "background" instead, ensuring the correct file is processed when uploading a profile background.