### PR TITLE
Update ProfileCreateDtoValidator validation rules

### DIFF
--- a/src/Gml.Web.Api/Core/Validation/ProfileCreateDtoValidator.cs
+++ b/src/Gml.Web.Api/Core/Validation/ProfileCreateDtoValidator.cs
@@ -9,7 +9,7 @@ public class ProfileCreateDtoValidator : AbstractValidator<ProfileCreateDto>
     {
         RuleFor(x => x.Name)
             .NotEmpty().WithMessage("Имя обязательно.")
-            .Matches("^[a-zA-Z0-9]*$").WithMessage("Имя может содержать только английские буквы и цифры.")
+            .Matches("^[a-zA-Z0-9- ]*$").WithMessage("Имя может содержать только английские буквы, цифры, пробелы и тире.")
             .Length(2, 100).WithMessage("Длина имени должна быть от 2 до 100 символов.");
         RuleFor(x => x.Description)
             .NotEmpty().WithMessage("Описание обязательно.")


### PR DESCRIPTION
The changes made in this commit expand the validation rules for the Name field in ProfileCreateDtoValidator. Now, besides alphanumeric characters, Name can also include spaces and hyphens, providing users with more flexibility.