### PR TITLE
Update FileWhiteListValidator to handle list of FileWhiteListDto

### DIFF
--- a/src/Gml.Web.Api/Core/Extensions/ValidatorsExtensions.cs
+++ b/src/Gml.Web.Api/Core/Extensions/ValidatorsExtensions.cs
@@ -32,7 +32,7 @@ public static class ValidatorsExtensions
             .AddScoped<IValidator<IntegrationUpdateDto>, IntegrationValidator>()
 
             // Files validator
-            .AddScoped<IValidator<FileWhiteListDto>, FileWhiteListValidator>()
+            .AddScoped<IValidator<List<FileWhiteListDto>>, FileWhiteListValidator>()
 
             // Launcher validator
             .AddScoped<IValidator<LauncherCreateDto>, LauncherCreateDtoValidator>()

--- a/src/Gml.Web.Api/Core/Handlers/IFileHandler.cs
+++ b/src/Gml.Web.Api/Core/Handlers/IFileHandler.cs
@@ -13,11 +13,11 @@ public interface IFileHandler
 
     static abstract Task<IResult> AddFileWhiteList(
         IGmlManager manager,
-        IValidator<FileWhiteListDto> validator,
-        FileWhiteListDto fileDto);
+        IValidator<List<FileWhiteListDto>> validator,
+        List<FileWhiteListDto> fileDto);
 
     static abstract Task<IResult> RemoveFileWhiteList(
         IGmlManager manager,
-        IValidator<FileWhiteListDto> validator,
-        FileWhiteListDto fileDto);
+        IValidator<List<FileWhiteListDto>> validator,
+        List<FileWhiteListDto> fileDto);
 }

--- a/src/Gml.Web.Api/Core/Validation/FileWhiteListValidator.cs
+++ b/src/Gml.Web.Api/Core/Validation/FileWhiteListValidator.cs
@@ -3,18 +3,21 @@ using Gml.Web.Api.Dto.Files;
 
 namespace Gml.Web.Api.Core.Validation;
 
-public class FileWhiteListValidator : AbstractValidator<FileWhiteListDto>
+public class FileWhiteListValidator : AbstractValidator<List<FileWhiteListDto>>
 {
     public FileWhiteListValidator()
     {
-        RuleFor(x => x.ProfileName)
-            .NotEmpty().WithMessage("Имя профиля обязательно.")
-            .Matches("^[a-zA-Z0-9]*$").WithMessage("Имя профиля может содержать только английские буквы и цифры.")
-            .Length(2, 100).WithMessage("Длина имени профиля должна быть от 2 до 100 символов.");
+        RuleForEach(x => x).ChildRules(child =>
+        {
+            child.RuleFor(x => x.ProfileName)
+                .NotEmpty().WithMessage("Имя профиля обязательно.")
+                .Matches("^[a-zA-Z0-9]*$").WithMessage("Имя профиля может содержать только английские буквы и цифры.")
+                .Length(2, 100).WithMessage("Длина имени профиля должна быть от 2 до 100 символов.");
 
-        RuleFor(x => x.Hash)
-            .NotEmpty().WithMessage("Хэш обязателен.")
-            .Matches("^[a-fA-F0-9]*$")
-            .WithMessage("Хэш может содержать только HEX символы (цифры от 0 до 9 и буквы от A до F).");
+            child.RuleFor(x => x.Hash)
+                .NotEmpty().WithMessage("Хэш обязателен.")
+                .Matches("^[a-fA-F0-9]*$")
+                .WithMessage("Хэш может содержать только HEX символы (цифры от 0 до 9 и буквы от A до F).");
+        });
     }
 }


### PR DESCRIPTION
The FileWhiteListValidator class has been updated to handle a list of FileWhiteListDto objects rather than a single object. Correspondingly, changes have been made in the AddFileWhiteList and RemoveFileWhiteList methods as well as in the ValidatorsExtensions class. The duplication of file hashes and profile names in the list of FileWhiteListDtos is handled to prevent redundant operations.