### PR TITLE
Update HttpStatusCodes in FileHandler

### DIFF
--- a/src/Gml.Web.Api/Core/Handlers/FileHandler.cs
+++ b/src/Gml.Web.Api/Core/Handlers/FileHandler.cs
@@ -59,7 +59,7 @@ public class FileHandler : IFileHandler
         }
 
         return Results.Ok(ResponseMessage.Create($"\"{fileDto.Count}\" файлов было успешно добавлено в White-Лист",
-            HttpStatusCode.NotFound));
+            HttpStatusCode.OK));
     }
 
     [Authorize]
@@ -99,6 +99,6 @@ public class FileHandler : IFileHandler
         }
 
         return Results.Ok(ResponseMessage.Create($"\"{fileDto.Count}\" файлов было успешно удалено из White-Листа",
-            HttpStatusCode.NotFound));
+            HttpStatusCode.OK));
     }
 }


### PR DESCRIPTION
The HttpStatusCodes of two responses in FileHandler.cs have been updated. The HTTP status was incorrectly set to 'NotFound' previously, they were supposed to be 'OK'. The affected responses are for the methods handling the addition and deletion of files to/from the white-list.