### PR TITLE
Update URL generation in MinecraftHandler

### DIFF
--- a/src/Gml.Web.Api/Core/Handlers/MinecraftHandler.cs
+++ b/src/Gml.Web.Api/Core/Handlers/MinecraftHandler.cs
@@ -83,13 +83,17 @@ public class MinecraftHandler : IMinecraftHandler
             {
                 Skin = new SkinCape
                 {
-                    Url = (await gmlManager.Integrations.GetSkinServiceAsync()).Replace("{userName}",
-                            user.Name) + $"/skin-{user.Uuid}"
+                    Url = (await gmlManager.Integrations.GetSkinServiceAsync())
+                        .Replace("{userName}",user.Name)
+                        .Replace("{userUuid}", user.Uuid)
+                        + $"?uuid/{Guid.NewGuid()}"
                 },
                 Cape = new SkinCape
                 {
-                    Url = (await gmlManager.Integrations.GetCloakServiceAsync()).Replace("{userName}",
-                            user.Name) + $"/cape-{user.Uuid}"
+                    Url = (await gmlManager.Integrations.GetCloakServiceAsync())
+                        .Replace("{userName}", user.Name)
+                        .Replace("{userUuid}", user.Uuid)
+                        + $"?uuid/{Guid.NewGuid()}"
                 }
             }
         };
@@ -148,11 +152,17 @@ public class MinecraftHandler : IMinecraftHandler
             {
                 Skin = new SkinCape
                 {
-                    Url = (await gmlManager.Integrations.GetSkinServiceAsync()).Replace("{userName}", user.Name)
+                    Url = (await gmlManager.Integrations.GetSkinServiceAsync())
+                        .Replace("{userName}", user.Name)
+                        .Replace("{userUuid}", user.Uuid)
+                        + $"?uuid/{Guid.NewGuid()}"
                 },
                 Cape = new SkinCape
                 {
-                    Url = (await gmlManager.Integrations.GetCloakServiceAsync()).Replace("{userName}", user.Name)
+                    Url = (await gmlManager.Integrations.GetCloakServiceAsync())
+                        .Replace("{userName}", user.Name)
+                        .Replace("{userUuid}", user.Uuid)
+                        + $"?uuid/{Guid.NewGuid()}"
                 }
             }
         };


### PR DESCRIPTION
This commit amends the URL generation for Skin and Cape services in MinecraftHandler.cs. It adds the replacement for a new placeholder "{userUuid}" and includes a random UUID at the end of each URL to ensure uniqueness. This change provides better tracking and distinction between different requests.