### PR TITLE
Add console logging for exceptions in AuthIntegrationHandler

### DIFF
--- a/src/Gml.Web.Api/Core/Handlers/AuthIntegrationHandler.cs
+++ b/src/Gml.Web.Api/Core/Handlers/AuthIntegrationHandler.cs
@@ -61,11 +61,13 @@ public class AuthIntegrationHandler : IAuthIntegrationHandler
         }
         catch (HttpRequestException exception)
         {
+            Console.WriteLine(exception);
             return Results.BadRequest(ResponseMessage.Create(
                 "Произошла ошибка при обмене данных с сервисом авторизации.", HttpStatusCode.InternalServerError));
         }
         catch (Exception exception)
         {
+            Console.WriteLine(exception);
             return Results.BadRequest(ResponseMessage.Create(exception.Message, HttpStatusCode.InternalServerError));
         }
 


### PR DESCRIPTION
This commit adds console logging for HttpRequestException and generic Exception caught in the AuthIntegrationHandler. These logs will aid in the debugging process when an error occurs during data exchange with the authorization service.